### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/nico0320/d7597683-8a17-4332-97cb-8047e8c2b557/ad7c30bf-64f5-4be9-923d-53571379e853/_apis/work/boardbadge/928c00c3-08f1-41ff-9fa8-fbd8d5e41046)](https://dev.azure.com/nico0320/d7597683-8a17-4332-97cb-8047e8c2b557/_boards/board/t/ad7c30bf-64f5-4be9-923d-53571379e853/Microsoft.RequirementCategory)
 # Test001


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nico0320/d7597683-8a17-4332-97cb-8047e8c2b557/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.